### PR TITLE
add `=` after the --config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you have `use-package` installed
 # Available options
 `--config` (default: `nil`)
 ```lisp
-(setq flycheck-golangci-lint-config "path/to/config"
+(setq flycheck-golangci-lint-config "path/to/config")
 ```
 
 `--deadline` (default: `1m`)

--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -57,7 +57,7 @@
 
 See URL `https://github.com/golangci/golangci-lint'."
   :command ("golangci-lint" "run" "--print-issued-lines=false"
-	    (option "--config" flycheck-golangci-lint-config concat)
+	    (option "--config=" flycheck-golangci-lint-config concat)
 	    (option "--deadline=" flycheck-golangci-lint-deadline concat)
 	    (option-flag "--tests" flycheck-golangci-lint-tests)
 	    (option-flag "--fast" flycheck-golangci-lint-fast)


### PR DESCRIPTION
The docs suggest
(setq flycheck-golangci-lint-config "path/to/config")

but I had to do
(setq flycheck-golangci-lint-config "=path/to/config")