### PR TITLE
explicitly set the output format

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -57,7 +57,7 @@
 
 See URL `https://github.com/golangci/golangci-lint'."
   :command ("golangci-lint" "run" "--print-issued-lines=false" "--out-format=line-number"
-	    (option "--config" flycheck-golangci-lint-config concat)
+	    (option "--config=" flycheck-golangci-lint-config concat)
 	    (option "--deadline=" flycheck-golangci-lint-deadline concat)
 	    (option-flag "--tests" flycheck-golangci-lint-tests)
 	    (option-flag "--fast" flycheck-golangci-lint-fast)

--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -56,7 +56,7 @@
   "A Go syntax checker using golangci-lint that's 5x faster than gometalinter
 
 See URL `https://github.com/golangci/golangci-lint'."
-  :command ("golangci-lint" "run" "--print-issued-lines=false"
+  :command ("golangci-lint" "run" "--print-issued-lines=false" "--out-format=line-number"
 	    (option "--config" flycheck-golangci-lint-config concat)
 	    (option "--deadline=" flycheck-golangci-lint-deadline concat)
 	    (option-flag "--tests" flycheck-golangci-lint-tests)


### PR DESCRIPTION
If the config file has some value like `json` set, this linter starts
doing wonky things like pointing to files that do not exist for the
next error.