### PR TITLE
Add option to enable golint when linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,10 @@ If you have `use-package` installed
 (setq flycheck-golangci-lint-fast t)
 ```
 
+`--enable=golint` (default: `nil`)
+```lisp
+(setq flycheck-golangci-lint-enable-golint t)
+```
+
 # Contribute
 Pull requests are welcomed :)

--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -47,6 +47,11 @@
   :safe #'booleanp
   :type 'boolean)
 
+(flycheck-def-option-var flycheck-golangci-lint-enable-golint nil golangci-lint
+  "Enable the 'golint' linter within golangci-lint"
+  :safe #'booleanp
+  :type 'boolean)
+
 (flycheck-def-option-var flycheck-golangci-lint-fast nil golangci-lint
   "Run only fast linters from the enabled set of linters. To find out which linters are fast run golangci-lint linters."
   :safe #'booleanp
@@ -61,6 +66,7 @@ See URL `https://github.com/golangci/golangci-lint'."
 	    (option "--deadline=" flycheck-golangci-lint-deadline concat)
 	    (option-flag "--tests" flycheck-golangci-lint-tests)
 	    (option-flag "--fast" flycheck-golangci-lint-fast)
+	    (option-flag "--enable=golint" flycheck-golangci-lint-enable-golint)
 	    ".")
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": " (message) line-end)


### PR DESCRIPTION
There are some things within `golint` that some may want to enforce on their
codebase, without needing to run the linter manually. Previously `golint` was
ran automatically for me until golangci-lint was enabled instead.

This change proposes adding an additional boolean flag to tell
`flycheck-golangci-lint` to enable the `golint` linter.

Signed-off-by: Tim Heckman <t@heckman.io>