### PR TITLE
fix when no go mod file present

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -89,6 +89,7 @@ See URL `https://github.com/golangci/golangci-lint'."
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": " (message) line-end)
    (error line-start (file-name) ":" line ":" (message) line-end))
+  :predicate (lambda () (not (string= "/dev/null\n" (shell-command-to-string "go env GOMOD"))))
   :modes go-mode)
 
 ;;;###autoload


### PR DESCRIPTION
When no go mod file is present and go can't figure out where it should be put (e.g., when working with a random file not in a git repo), golangci-lint throws a fit and exits.

This change disables the lint when go can't find the project root.