### PR TITLE
switch to checkstyle format to enable severity

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -76,7 +76,7 @@
   "A Go syntax checker using golangci-lint that's 5x faster than gometalinter
 
 See URL `https://github.com/golangci/golangci-lint'."
-  :command ("golangci-lint" "run" "--print-issued-lines=false" "--out-format=line-number"
+  :command ("golangci-lint" "run" "--out-format=checkstyle"
             (option "--config=" flycheck-golangci-lint-config concat)
             (option "--deadline=" flycheck-golangci-lint-deadline concat)
             (option-flag "--tests" flycheck-golangci-lint-tests)
@@ -86,6 +86,7 @@ See URL `https://github.com/golangci/golangci-lint'."
             (option-list "--disable=" flycheck-golangci-lint-disable-linters concat)
             (option-list "--enable=" flycheck-golangci-lint-enable-linters concat)
             ".")
+  :error-parser flycheck-parse-checkstyle
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": " (message) line-end)
    (error line-start (file-name) ":" line ":" (message) line-end))


### PR DESCRIPTION
I've tested this in my emacs config, and it seems to solve the issue of linter severity being ignored by flycheck. Previously I'd tried the solution proposed in https://github.com/weijiangan/flycheck-golangci-lint/pull/9, but this didn't work for me. 