### PR TITLE
Run golangci-lint on save only

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -102,7 +102,8 @@ See URL `https://github.com/golangci/golangci-lint'."
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": " (message) line-end)
    (error line-start (file-name) ":" line ":" (message) line-end))
-  :modes go-mode)
+  :modes go-mode
+  :predicate flycheck-buffer-saved-p)
 
 ;;;###autoload
 (defun flycheck-golangci-lint-setup ()


### PR DESCRIPTION
Since golangci-lint checks original files, we can only use this checker if the buffer is actually saved and is equal to the disk file. I don't think any reason exists to run golangci-lint on every change, because it'll show us outdated info, because not saved buffer differs from its on disk file.