### PR TITLE
Change deadline option to timeout

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -88,7 +88,7 @@
 See URL `https://github.com/golangci/golangci-lint'."
   :command ("golangci-lint" "run" "--out-format=checkstyle"
             (option "--config=" flycheck-golangci-lint-config concat)
-            (option "--deadline=" flycheck-golangci-lint-deadline concat)
+            (option "--timeout=" flycheck-golangci-lint-deadline concat)
             (option-flag "--tests" flycheck-golangci-lint-tests)
             (option-flag "--fast" flycheck-golangci-lint-fast)
             (option-flag "--allow-parallel-runners" flycheck-golangci-allow-parallel-runners)


### PR DESCRIPTION
golangci-lint added the `--timeout` option to replace `--deadline` in 2019: https://github.com/golangci/golangci-lint/pull/793

In v1.57.0, they fully removed the `--deadline` option, breaking the current package: https://github.com/golangci/golangci-lint/releases/tag/v1.57.0

This changes the `--deadline` option for the `--timeout` option, but leaves the configuration for it as-is to not break existing configuration.