### PR TITLE
Add support for go-ts-mode

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -102,7 +102,7 @@ See URL `https://github.com/golangci/golangci-lint'."
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": " (message) line-end)
    (error line-start (file-name) ":" line ":" (message) line-end))
-  :modes go-mode)
+  :modes (go-mode go-ts-mode))
 
 ;;;###autoload
 (defun flycheck-golangci-lint-setup ()


### PR DESCRIPTION
Now that everyone's jumping on the treesitter bandwagon, it would be great if the golangci-lint flychecker could be added for that major mode as well.

Thanks!