### PR TITLE
Fix v2 output format issue causing raw XML display

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -91,7 +91,7 @@ Returns a list of (major minor patch) as integers, or nil if parsing fails."
   (unless flycheck-golangci-lint--version
     (let* ((output (ignore-errors
                      (with-temp-buffer
-                       (call-process "golangci-lint" nil t nil "--version")
+                       (call-process flycheck-golangci-lint-executable nil t nil "--version")
                        (buffer-string))))
            (version-regex "version \\([0-9]+\\)\\.\\([0-9]+\\)\\.\\([0-9]+\\)"))
       (when (and output (string-match version-regex output))


### PR DESCRIPTION
Hey @weijiangan - thanks for your work on the package and the work of other contributors!

I ran across an issue and wanted to see if you'd be open to this change.

## Background

This PR fixes the issue where golangci-lint v2.x would display raw XML in the buffer instead of showing inline errors.

The current implementation (from PR #21) uses both `--output.checkstyle.path=stdout` and `--output.text.path=stderr`. However, in golangci-lint v2.x, this causes mixed output on stdout (XML + text summary) which breaks Flycheck's `checkstyle` parser, resulting in raw XML being dumped to the buffer.

It seems to me then in my testing that the root cause is `--output.text.path=stderr` doesn't prevent the text summary from being appended to stdout. Both v2.4.0 and v2.5.0 exhibit this behavior on my end, anecdotally.

## Solution

To address this, I've added version detection to distinguish between v1.x and v2.

  - v1.x: Use legacy `--out-format=checkstyle` flag
  - v2.x: Use `--output.checkstyle.path=stdout` without `--output.text.path=stderr`
  - Cache version detection for performance (only runs once per Emacs session)

## Testing
I've tested the following:
  - golangci-lint v1.57.2 
  - golangci-lint v2.4.0 
  - golangci-lint v2.5.0 

All versions now properly display inline errors without raw XML output.

Additional context on my testing methodology for transparency...

1. Downloaded each version from GitHub releases
2. Tested both output configurations (with and without `--output.text.path=stderr`)
3. Verified that stdout contains clean `checkstyle` XML
4. Confirmed inline errors display correctly in Emacs buffer
5. Tested version detection switches correctly between v1 and v2 flags

## System Info
Flycheck version: 35.0
Emacs version: 30.2
System: aarch64-apple-darwin24.6.0