### PR TITLE
Add '--path-mode=abs' option to golangci-lint

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -90,6 +90,7 @@ See URL `https://github.com/golangci/golangci-lint'."
             "run"
             "--output.checkstyle.path=stdout"
             "--output.text.path=stderr"
+            "--path-mode=abs"
             (option "--config=" flycheck-golangci-lint-config concat)
             (option "--timeout=" flycheck-golangci-lint-deadline concat)
             (option-flag "--tests" flycheck-golangci-lint-tests)


### PR DESCRIPTION
The default uses the path relative to the config file. Flycheck is unable to parse the output to produce the correct syntax highlightings.