### PR TITLE
Make sure the exec name is really found and saved buffer locally

### DIFF
--- a/flycheck-golangci-lint.el
+++ b/flycheck-golangci-lint.el
@@ -82,7 +82,7 @@
   :type '(repeat (string :tag "linter"))
   :safe #'flycheck-string-list-p)
 
-(defvar flycheck-golangci-lint--version nil
+(defvar-local flycheck-golangci-lint--version nil
   "Cached golangci-lint version as (major minor patch).")
 
 (defun flycheck-golangci-lint--parse-version ()
@@ -91,7 +91,9 @@ Returns a list of (major minor patch) as integers, or nil if parsing fails."
   (unless flycheck-golangci-lint--version
     (let* ((output (ignore-errors
                      (with-temp-buffer
-                       (call-process flycheck-golangci-lint-executable nil t nil "--version")
+                       (call-process (or flycheck-golangci-lint-executable
+                                         (car (flycheck-checker-get 'golangci-lint 'command)))
+                                     nil t nil "--version")
                        (buffer-string))))
            (version-regex "version \\([0-9]+\\)\\.\\([0-9]+\\)\\.\\([0-9]+\\)"))
       (when (and output (string-match version-regex output))


### PR DESCRIPTION
f7e36e19d6af39d098b94a2e7524dbd7b585ce67 is not ideal because it requires the user to set `flycheck-golangci-lint-executable`, which is nil by default. This PR uses a flycheck internal function to default the command back to the command set in the checker declaration.

This PR also caches the version per buffer instead of globally.